### PR TITLE
feat(devx): updated dev script to work on Windows machines

### DIFF
--- a/packages/app/utils/constants.js
+++ b/packages/app/utils/constants.js
@@ -1,3 +1,3 @@
-const URL = "https://bb9d-47-229-131-248.ngrok.io";
+const URL = "https://840b-2600-1700-7860-56a0-1c49-4af5-1a50-8afb.ngrok.io";
 
 export const ENDPOINT = `${URL}/api`;


### PR DESCRIPTION
- Improves on the dev script by @exelarios to allow Windows developers to run the entire stack and set up ngrok with a single command
- Developers must have the folder containing their ngrok executable set in their Path Windows system environment variable.