### PR TITLE
Post-checkout Git hooks for better developer experience

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn
+yarn workspace server prisma generate

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "server:test": "yarn workspace server test",
     "port:forward": "yarn workspace server forward",
     "reset": "find . -type dir -name node_modules | xargs rm -rf && yarn",
-    "dev": "node ./scripts/run.js"
+    "dev": "node ./scripts/run.js",
+    "postinstall": "husky install"
   },
   "description": "organization engagement platform",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "eslint": "8.39.0",
     "eslint-config-prettier": "^9.0.0",
+    "husky": "^8.0.3",
     "prettier": "2.8.8"
   },
   "repository": "https://github.com/cppsea/icebreak.git"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5471,6 +5471,11 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+husky@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"


### PR DESCRIPTION
I added Git hooks for post-checkout to automate the following:
- sync dependencies for the checked-out branch with `yarn install`
- generate Prisma client to interact with our database in code