### PR TITLE
fix: replaced similarity search with word similarity search

### DIFF
--- a/packages/server/controllers/guilds.js
+++ b/packages/server/controllers/guilds.js
@@ -39,15 +39,15 @@ async function deleteGuild(guildId) {
 async function searchGuildByName(pattern) {
   return prisma.$queryRaw`
     SELECT guild_id, name, handler, icon FROM guilds 
-    WHERE SIMILARITY(name, ${pattern}) > ${MINIMUM_SIMILARITY}
-    ORDER BY SIMILARITY(name, ${pattern}) DESC;`;
+    WHERE WORD_SIMILARITY(${pattern}, name) > ${MINIMUM_SIMILARITY}
+    ORDER BY WORD_SIMILARITY(${pattern}, name) DESC;`;
 }
 
 async function searchGuildByHandler(pattern) {
   return prisma.$queryRaw`
     SELECT guild_id, name, handler, icon FROM guilds 
-    WHERE SIMILARITY(handler, ${pattern}) > ${MINIMUM_SIMILARITY}
-    ORDER BY SIMILARITY(handler, ${pattern}) DESC;`;
+    WHERE SIMILARITY(${pattern}, handler) > ${MINIMUM_SIMILARITY}
+    ORDER BY SIMILARITY(${pattern}, handler) DESC;`;
 }
 
 async function guildExists(guildId) {


### PR DESCRIPTION
This calculates the greatest similarity between the search pattern and any substring of the guild's name instead of the entire name as one string. It makes it easier to search for guilds which have multiple words in their name.