### PR TITLE
Justin/api guild leaderboard

### DIFF
--- a/packages/server/controllers/guilds.js
+++ b/packages/server/controllers/guilds.js
@@ -82,35 +82,34 @@ async function getGuildMembers(guildId) {
   return members;
 }
 
-async function getGuildMembersPoints(guildId) {
-  const getMembers = await prisma.guildMembers.findMany({
+async function guildLeaderboard(guildId) {
+  const guildLeaderboard = await prisma.guildMembers.findMany({
     where: {
       guildId: guildId,
     },
 
-    orderBy: [
-      {
-        members: {
-          points: "asc",
-        },
-      },
-    ],
     include: {
-      select: {
-        members: {
-          select: {
-            firstName: true,
-            lastName: true,
-            handler: true,
-            avatar: true,
-            points: true,
-          },
+      members: {
+        select: {
+          firstName: true,
+          lastName: true,
+          handler: true,
+          avatar: true,
         },
       },
     },
+
+    orderBy: [
+      {
+        points: "asc",
+      },
+    ],
   });
 
-  const members = getMembers.flatMap((member) => member.members);
+  const members = guildLeaderboard.map((member) => ({
+    ...member.members,
+    points: member.points,
+  }));
 
   return members;
 }
@@ -125,5 +124,5 @@ module.exports = {
   deleteGuild,
   getGuildMembers,
   guildExists,
-  getGuildMembersPoints,
+  guildLeaderboard,
 };

--- a/packages/server/controllers/guilds.js
+++ b/packages/server/controllers/guilds.js
@@ -82,6 +82,39 @@ async function getGuildMembers(guildId) {
   return members;
 }
 
+async function getGuildMembersPoints(guildId) {
+  const getMembers = await prisma.guildMembers.findMany({
+    where: {
+      guildId: guildId,
+    },
+
+    orderBy: [
+      {
+        members: {
+          points: "asc",
+        },
+      },
+    ],
+    include: {
+      select: {
+        members: {
+          select: {
+            firstName: true,
+            lastName: true,
+            handler: true,
+            avatar: true,
+            points: true,
+          },
+        },
+      },
+    },
+  });
+
+  const members = getMembers.flatMap((member) => member.members);
+
+  return members;
+}
+
 module.exports = {
   getGuild,
   searchGuildByName,
@@ -92,4 +125,5 @@ module.exports = {
   deleteGuild,
   getGuildMembers,
   guildExists,
+  getGuildMembersPoints,
 };

--- a/packages/server/controllers/guilds.js
+++ b/packages/server/controllers/guilds.js
@@ -101,7 +101,7 @@ async function guildLeaderboard(guildId) {
 
     orderBy: [
       {
-        points: "asc",
+        points: "desc",
       },
     ],
   });

--- a/packages/server/controllers/guilds.js
+++ b/packages/server/controllers/guilds.js
@@ -82,7 +82,7 @@ async function getGuildMembers(guildId) {
   return members;
 }
 
-async function guildLeaderboard(guildId) {
+async function getLeaderboard(guildId) {
   const guildLeaderboard = await prisma.guildMembers.findMany({
     where: {
       guildId: guildId,
@@ -124,5 +124,5 @@ module.exports = {
   deleteGuild,
   getGuildMembers,
   guildExists,
-  guildLeaderboard,
+  getLeaderboard,
 };

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -16,6 +16,7 @@ model users {
   email          String           @unique @db.VarChar(255)
   avatar         String?          @db.VarChar(255)
   password       String?          @db.VarChar(255)
+  handler        String?          @db.VarChar(50)
   eventAttendees eventAttendees[]
   guildMembers   guildMembers[]
 }

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -46,6 +46,7 @@ model events {
 model guildMembers {
   userId  String @map("user_id") @db.Uuid
   guildId String @map("guild_id") @db.Uuid
+  points  Int    @db.SmallInt
   guilds  guilds @relation(fields: [guildId], references: [guildId], onDelete: Cascade, onUpdate: NoAction, map: "fk_guild")
   members users  @relation(fields: [userId], references: [userId], onDelete: Cascade, onUpdate: NoAction, map: "fk_user")
 

--- a/packages/server/routes/api/guilds.js
+++ b/packages/server/routes/api/guilds.js
@@ -242,4 +242,41 @@ router.get(
   }
 );
 
+router.get(
+  "/:guildId/leaderboard",
+  AuthController.authenticate,
+  guildIdValidator,
+  async (request, response) => {
+    const result = validationResult(request);
+
+    if (!result.isEmpty()) {
+      return response.status(400).json({
+        status: "fail",
+        data: result.array(),
+      });
+    }
+
+    const data = matchedData(request);
+    const guildId = data.guildId;
+
+    try {
+      const guildsMembersPoints = await GuildController.getGuildMembersPoints(
+        guildId
+      );
+
+      response.status(200).json({
+        status: "success",
+        data: {
+          guildsMembersPoints,
+        },
+      });
+    } catch (error) {
+      response.status(500).json({
+        status: "error",
+        message: error.message,
+      });
+    }
+  }
+);
+
 module.exports = router;

--- a/packages/server/routes/api/guilds.js
+++ b/packages/server/routes/api/guilds.js
@@ -260,14 +260,12 @@ router.get(
     const guildId = data.guildId;
 
     try {
-      const guildsMembersPoints = await GuildController.getGuildMembersPoints(
-        guildId
-      );
+      const guildLeaderboard = await GuildController.guildLeaderboard(guildId);
 
       response.status(200).json({
         status: "success",
         data: {
-          guildsMembersPoints,
+          guildLeaderboard,
         },
       });
     } catch (error) {

--- a/packages/server/routes/api/guilds.js
+++ b/packages/server/routes/api/guilds.js
@@ -260,7 +260,7 @@ router.get(
     const guildId = data.guildId;
 
     try {
-      const guildLeaderboard = await GuildController.guildLeaderboard(guildId);
+      const guildLeaderboard = await GuildController.getLeaderboard(guildId);
 
       response.status(200).json({
         status: "success",

--- a/packages/server/validators/guilds.js
+++ b/packages/server/validators/guilds.js
@@ -12,6 +12,7 @@ const guildIdValidator = [
     .escape()
     .isUUID()
     .withMessage("Guild ID not a valid UUID.")
+    .bail()
     .custom(async (value) => {
       try {
         await GuildController.getGuild(value);


### PR DESCRIPTION
This API route will allow the app to display a leaderboard for the guild and the top participating members. This is our way of "gamifying" the app and incentivizing participation for university clubs in our app.

API route should return

- list of guild members sorted by how many points they have from most to least
- the following guild member info
- first and last name
- avatar
- their current amount of points in the guild