### PR TITLE
API Checking in to Guild Event

### DIFF
--- a/packages/server/controllers/events.js
+++ b/packages/server/controllers/events.js
@@ -122,6 +122,22 @@ async function getEventAttendees(eventId) {
   return query;
 }
 
+async function updateAttendeeStatus(eventId, userId, attendeeStatus) {
+  const query = await prisma.eventAttendees.update({
+    where: {
+      userId_eventId: {
+        userId: userId,
+        eventId: eventId,
+      },
+    },
+    data: {
+      status: attendeeStatus,
+    },
+  });
+
+  return query;
+}
+
 module.exports = {
   getEvent,
   getEvents,
@@ -131,4 +147,5 @@ module.exports = {
   updateEvent,
   createEvent,
   getEventAttendees,
+  updateAttendeeStatus,
 };

--- a/packages/server/controllers/events.js
+++ b/packages/server/controllers/events.js
@@ -122,7 +122,7 @@ async function getEventAttendees(eventId) {
   return query;
 }
 
-async function updateAttendeeStatus(eventId, userId, attendeeStatus) {
+async function updateAttendeeStatus(eventId, userId) {
   const query = await prisma.eventAttendees.update({
     where: {
       userId_eventId: {
@@ -131,7 +131,7 @@ async function updateAttendeeStatus(eventId, userId, attendeeStatus) {
       },
     },
     data: {
-      status: attendeeStatus,
+      status: "CheckedIn",
     },
   });
 

--- a/packages/server/controllers/events.js
+++ b/packages/server/controllers/events.js
@@ -122,14 +122,19 @@ async function getEventAttendees(eventId) {
 }
 
 async function updateAttendeeStatus(eventId, userId, attendeeStatus) {
-  const query = await prisma.eventAttendees.update({
+  const query = await prisma.eventAttendees.upsert({
     where: {
       userId_eventId: {
         userId: userId,
         eventId: eventId,
       },
     },
-    data: {
+    create: {
+      userId: userId,
+      eventId: eventId,
+      status: attendeeStatus,
+    },
+    update: {
       status: attendeeStatus,
     },
   });
@@ -175,7 +180,7 @@ async function addCheckInPoints(eventId, userId) {
 
   await prisma.guildMembers.update({
     where: {
-      userId_guildId: {
+      guildId_userId: {
         userId: userId,
         guildId: event.guildId,
       },

--- a/packages/server/controllers/events.js
+++ b/packages/server/controllers/events.js
@@ -121,7 +121,7 @@ async function getEventAttendees(eventId) {
   return query;
 }
 
-async function updateAttendeeStatus(eventId, userId) {
+async function updateAttendeeStatus(eventId, userId, attendeeStatus) {
   const query = await prisma.eventAttendees.update({
     where: {
       userId_eventId: {
@@ -130,7 +130,7 @@ async function updateAttendeeStatus(eventId, userId) {
       },
     },
     data: {
-      status: "CheckedIn",
+      status: attendeeStatus,
     },
   });
 

--- a/packages/server/controllers/events.js
+++ b/packages/server/controllers/events.js
@@ -153,7 +153,7 @@ async function addCheckInPoints(eventId, userId) {
     },
     select: {
       startDate: true,
-      guildId: true, // Assuming you need the guild ID to find the guildMember
+      guildId: true,
     },
   });
 
@@ -163,7 +163,6 @@ async function addCheckInPoints(eventId, userId) {
   const eventStartTime = event.startDate.getTime();
   const fiveMinutesInMilliseconds = 5 * 60 * 1000;
   const currentTimeInMilliseconds = currentTime.getTime();
-  //Default points to add
   let pointsToAdd = 3;
 
   if (

--- a/packages/server/controllers/guilds.js
+++ b/packages/server/controllers/guilds.js
@@ -115,7 +115,7 @@ async function getLeaderboard(guildId) {
 }
 
 async function isGuildMember(guildId, userId) {
-  const guildMember = await prisma.guildMembers.findFirst({
+  const guildMember = await prisma.guildMembers.findUnique({
     where: {
       guildId: guildId,
       userId: userId,

--- a/packages/server/controllers/guilds.js
+++ b/packages/server/controllers/guilds.js
@@ -114,6 +114,16 @@ async function getLeaderboard(guildId) {
   return members;
 }
 
+async function isGuildMember(guildId, userId) {
+  const guildMember = await prisma.guildMembers.findFirst({
+    where: {
+      guildId: guildId,
+      userId: userId,
+    },
+  });
+  return !!guildMember;
+}
+
 module.exports = {
   getGuild,
   searchGuildByName,
@@ -125,4 +135,5 @@ module.exports = {
   getGuildMembers,
   guildExists,
   getLeaderboard,
+  isGuildMember,
 };

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -22,12 +22,12 @@ model users {
 }
 
 enum Status {
-  NotInterested
-  Interested
-  Attending
-  CheckedIn
+  NotInterested @map("not interested")
+  Interested    @map("interested")
+  Attending     @map("attending")
+  CheckedIn     @map("checked in")
 
-  @@map("event_attendees")
+  @@map("event_attendee_status")
 }
 
 model eventAttendees {
@@ -38,6 +38,7 @@ model eventAttendees {
   status    Status @default(NotInterested)
 
   @@id([userId, eventId])
+  @@map("event_attendees")
 }
 
 model events {

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -21,14 +21,23 @@ model users {
   guildMembers   guildMembers[]
 }
 
+enum Status {
+  NotInterested
+  Interested
+  Attending
+  CheckedIn
+
+  @@map("event_attendees")
+}
+
 model eventAttendees {
   userId    String @map("user_id") @db.Uuid
   eventId   String @map("event_id") @db.Uuid
   events    events @relation(fields: [eventId], references: [eventId], onDelete: Cascade, onUpdate: NoAction, map: "fk_event")
   attendees users  @relation(fields: [userId], references: [userId], onDelete: Cascade, onUpdate: NoAction, map: "fk_user")
+  status    Status @default(NotInterested)
 
   @@id([userId, eventId])
-  @@map("event_attendees")
 }
 
 model events {

--- a/packages/server/routes/api/events.js
+++ b/packages/server/routes/api/events.js
@@ -288,10 +288,11 @@ router.post(
     const errors = validationResult(request);
 
     if (!errors.isEmpty()) {
-      return response.status(400).json({
+      response.status(400).json({
         status: "fail",
         data: errors.array(),
       });
+      return;
     }
 
     try {

--- a/packages/server/routes/api/events.js
+++ b/packages/server/routes/api/events.js
@@ -7,6 +7,7 @@ const {
   updateEventValidator,
   eventIdValidator,
 } = require("../../validators/events");
+const { userIdBodyValidator } = require("../../validators/users");
 const { validationResult, matchedData } = require("express-validator");
 const DEFAULT_EVENT_LIMIT = 10;
 /**
@@ -284,6 +285,7 @@ router.post(
   "/:eventId/check-in",
   AuthController.authenticate,
   eventIdValidator,
+  userIdBodyValidator,
   async (request, response) => {
     const errors = validationResult(request);
 

--- a/packages/server/routes/api/events.js
+++ b/packages/server/routes/api/events.js
@@ -298,19 +298,21 @@ router.post(
     }
 
     try {
-      const { status, userId } = request.body;
-      const eventId = request.params.eventId;
+      const { userId, eventId } = matchedData(request);
       const event = await EventController.getEvent(eventId);
 
       const currentTime = new Date();
-      const checkInStartTime = new Date(event.startDate.getTime() - 5 * 60000);
-      const checkInEndTime = new Date(event.endDate.getTime() + 15 * 60000);
+
+      const EVENT_START_TIME = event.startDate.getTime() - 5 * 60000;
+      const EVENT_END_TIME = event.endDate.getTime() + 15 * 60000;
+
+      const checkInStartTime = new Date(EVENT_START_TIME);
+      const checkInEndTime = new Date(EVENT_END_TIME);
 
       if (currentTime >= checkInStartTime && currentTime <= checkInEndTime) {
         const eventAttendeeData = await EventController.updateAttendeeStatus(
           eventId,
-          userId,
-          status
+          userId
         );
 
         response.status(200).json({

--- a/packages/server/routes/api/events.js
+++ b/packages/server/routes/api/events.js
@@ -280,4 +280,43 @@ router.get(
   }
 );
 
+router.post(
+  "/:eventId/check-in",
+  AuthController.authenticate,
+  eventIdValidator,
+  async (request, response) => {
+    const errors = validationResult(request);
+
+    if (!errors.isEmpty()) {
+      return response.status(400).json({
+        status: "fail",
+        data: errors.array(),
+      });
+    }
+
+    try {
+      const { status, userId } = request.body;
+      const eventId = request.params.eventId;
+
+      const eventAttendeeData = await EventController.updateAttendeeStatus(
+        eventId,
+        userId,
+        status
+      );
+
+      response.status(200).json({
+        status: "success",
+        data: {
+          eventRegistration: eventAttendeeData,
+        },
+      });
+    } catch (error) {
+      response.status(500).json({
+        status: "error",
+        message: error.message,
+      });
+    }
+  }
+);
+
 module.exports = router;

--- a/packages/server/routes/api/events.js
+++ b/packages/server/routes/api/events.js
@@ -300,19 +300,32 @@ router.post(
     try {
       const { status, userId } = request.body;
       const eventId = request.params.eventId;
+      const event = await EventController.getEvent(eventId);
 
-      const eventAttendeeData = await EventController.updateAttendeeStatus(
-        eventId,
-        userId,
-        status
-      );
+      const currentTime = new Date();
+      const checkInStartTime = new Date(event.startDate.getTime() - 5 * 60000);
+      const checkInEndTime = new Date(event.endDate.getTime() + 15 * 60000);
 
-      response.status(200).json({
-        status: "success",
-        data: {
-          eventRegistration: eventAttendeeData,
-        },
-      });
+      if (currentTime >= checkInStartTime && currentTime <= checkInEndTime) {
+        const eventAttendeeData = await EventController.updateAttendeeStatus(
+          eventId,
+          userId,
+          status
+        );
+
+        response.status(200).json({
+          status: "success",
+          data: {
+            eventRegistration: eventAttendeeData,
+          },
+        });
+      } else {
+        // Return error if check-in window has closed
+        response.status(403).json({
+          status: "fail",
+          message: "Check-in window has closed.",
+        });
+      }
     } catch (error) {
       response.status(500).json({
         status: "error",

--- a/packages/server/routes/api/events.js
+++ b/packages/server/routes/api/events.js
@@ -7,6 +7,7 @@ const {
   updateEventValidator,
   eventIdValidator,
 } = require("../../validators/events");
+const { userIdBodyValidator } = require("../../validators/users");
 const { validationResult, matchedData } = require("express-validator");
 const DEFAULT_EVENT_LIMIT = 10;
 /**
@@ -271,6 +272,66 @@ router.get(
           eventAttendees: eventAttendeesData,
         },
       });
+    } catch (error) {
+      response.status(500).json({
+        status: "error",
+        message: error.message,
+      });
+    }
+  }
+);
+
+router.post(
+  "/:eventId/check-in",
+  AuthController.authenticate,
+  eventIdValidator,
+  userIdBodyValidator,
+  async (request, response) => {
+    const errors = validationResult(request);
+
+    if (!errors.isEmpty()) {
+      response.status(400).json({
+        status: "fail",
+        data: errors.array(),
+      });
+      return;
+    }
+
+    try {
+      const { userId, eventId } = matchedData(request);
+      const event = await EventController.getEvent(eventId);
+
+      const currentTime = new Date();
+
+      const MINUTES_TO_MILLISECONDS = 60000;
+      const eventCheckInStartBound =
+        event.startDate.getTime() - 5 * MINUTES_TO_MILLISECONDS;
+      const eventCheckInEndBound =
+        event.startDate.getTime() + 15 * MINUTES_TO_MILLISECONDS;
+
+      const checkInStartTime = new Date(eventCheckInStartBound);
+      const checkInEndTime = new Date(eventCheckInEndBound);
+
+      if (currentTime >= checkInStartTime && currentTime <= checkInEndTime) {
+        const eventAttendeeData = await EventController.updateAttendeeStatus(
+          eventId,
+          userId,
+          "CheckedIn"
+        );
+
+        response.status(200).json({
+          status: "success",
+          data: {
+            eventRegistration: eventAttendeeData,
+          },
+        });
+      } else {
+        // Return error if check-in window has closed
+        response.status(403).json({
+          status: "fail",
+          message: "Check-in window has closed.",
+        });
+      }
     } catch (error) {
       response.status(500).json({
         status: "error",

--- a/packages/server/routes/api/events.js
+++ b/packages/server/routes/api/events.js
@@ -303,16 +303,20 @@ router.post(
 
       const currentTime = new Date();
 
-      const EVENT_START_TIME = event.startDate.getTime() - 5 * 60000;
-      const EVENT_END_TIME = event.endDate.getTime() + 15 * 60000;
+      const MINUTES_TO_MILLISECONDS = 60000;
+      const eventCheckInStartBound =
+        event.startDate.getTime() - 5 * MINUTES_TO_MILLISECONDS;
+      const eventCheckInEndBound =
+        event.startDate.getTime() + 15 * MINUTES_TO_MILLISECONDS;
 
-      const checkInStartTime = new Date(EVENT_START_TIME);
-      const checkInEndTime = new Date(EVENT_END_TIME);
+      const checkInStartTime = new Date(eventCheckInStartBound);
+      const checkInEndTime = new Date(eventCheckInEndBound);
 
       if (currentTime >= checkInStartTime && currentTime <= checkInEndTime) {
         const eventAttendeeData = await EventController.updateAttendeeStatus(
           eventId,
-          userId
+          userId,
+          "CheckedIn"
         );
 
         response.status(200).json({

--- a/packages/server/validators/events.js
+++ b/packages/server/validators/events.js
@@ -222,7 +222,10 @@ const checkInTimeValidator = [
       const checkInStartTime = new Date(eventCheckInStartBound);
       const checkInEndTime = new Date(eventCheckInEndBound);
 
-      if (currentTime < checkInStartTime || currentTime > checkInEndTime) {
+      if (currentTime < checkInStartTime) {
+        throw new Error("This event has not opened for check-in yet.");
+      }
+      if (currentTime > checkInEndTime) {
         throw new Error("Check-in window has closed.");
       }
     }),

--- a/packages/server/validators/users.js
+++ b/packages/server/validators/users.js
@@ -25,6 +25,7 @@ const userIdBodyValidator = [
     .blacklist("<>")
     .isUUID()
     .withMessage("Invalid user ID provided")
+    .bail()
     .custom(async (value) => {
       try {
         await UserController.getUser(value);

--- a/packages/server/validators/users.js
+++ b/packages/server/validators/users.js
@@ -1,4 +1,4 @@
-const { param } = require("express-validator");
+const { param, body } = require("express-validator");
 
 const UserController = require("../controllers/users");
 
@@ -18,6 +18,23 @@ const userIdValidator = [
     }),
 ];
 
+const userIdBodyValidator = [
+  body("userId")
+    .notEmpty()
+    .withMessage("User ID cannot be empty")
+    .blacklist("<>")
+    .isUUID()
+    .withMessage("Invalid user ID provided")
+    .custom(async (value) => {
+      try {
+        await UserController.getUser(value);
+      } catch (error) {
+        throw new Error("User with ID ${value} not found");
+      }
+    }),
+];
+
 module.exports = {
   userIdValidator,
+  userIdBodyValidator,
 };


### PR DESCRIPTION
When an event is about to start or has started recently, we want to allow event attendees to check in to the event so they're eligible to gain points for club participation. Guild members can only obtain points if they have checked in. 

This API route will be called to change the status of a guild member:
- not interested
- interested
- attending
- checked in

[RFC](https://doc.clickup.com/9011073139/d/h/8chm43k-3571/29ca28344f7005b)